### PR TITLE
0603 webproducer should be graphql provider agnostic

### DIFF
--- a/src/GraphQLDataProvider.js
+++ b/src/GraphQLDataProvider.js
@@ -97,9 +97,9 @@ class GraphQLDataProvider {
           // 1.fetch query
           const graphQLOptions = {
             query: dataFiles["query.graphql"],
-            endpoint: "https://graphql.datocms.com/",
+            endpoint: options.graphQL.apiEndpoint,
             transform: dataFiles["transform.js"],
-            token: options.datoCMSToken,
+            token: options.graphQL.apiToken,
             preview: options.preview,
           };
 

--- a/src/Vinyl-Handlebars.js
+++ b/src/Vinyl-Handlebars.js
@@ -88,16 +88,16 @@ class VinylHandlebars {
       const fields = data[key];
 
       // Only attempt to build a page if the fields data contains a reference to the physical ebs file to use
-      if (fields && fields._modelApiKey && templates[`${fields._modelApiKey}.hbs`]) {
-        // Merge the data element with the template indicated in the data elements _modelApiKey property (required)
-        const result = templates[`${fields._modelApiKey}.hbs`](fields);
+      if (fields && fields.modelName && templates[`${fields.modelName}.hbs`]) {
+        // Merge the data element with the template indicated in the data elements modelName property (required)
+        const result = templates[`${fields.modelName}.hbs`](fields);
 
         // key.trim() required to cleanup any spaces that sometimes get added by the content editor
         const vf = new Vinyl({ path: key.trim().slice(1), contents: Buffer.from(result) });
         stream.write(vf);
         pages++;
       } else {
-        console.error(`Missing _modelApiKey for >${key}<`);
+        console.error(`Missing modelName for >${key}<`);
       }
     }
     stream.end();

--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,6 @@ class WebProducer {
     //this.templateSource = this._vinylesque(options.templateSource);
     this.destination = this._vinylesque(options.destination);
 
-    // Optional user function to further shape data retrieved from CMS source
-    this.transformFunction = options.transformFunction;
     // Name of S3 bucket to upload this.dist contents to
     this.amplify = options.amplify;
     // Additional AWS options, including ./aws/credentials profile


### PR DESCRIPTION
The following changes were made to WebProducer to improve support for different GraphQL providers:
- Vinyl-Handlebars.js expects modelName instead of DatoCMS specific _modelApiKey
- GraphQLDataProvider.js replaces options.datoCMSToken with options.apiToken and endpoint becomes options.graphQL.apiEndpoint
- Removed this.transformFunction from index.js as the transform function is now part of source/db

Note that this is a breaking change and requires projects that use WebProducer to expose the new modelName parameter in their GraphQL queries. A PR is queued for YMWA project that will update its graphql.query file accordingly, and will be submitted after this one is approved.