### PR TITLE
0691 deploy 301 redirects to s3+cloudfront

### DIFF
--- a/src/PageBuilder.js
+++ b/src/PageBuilder.js
@@ -19,6 +19,7 @@ const Vinyl = require("vinyl");
 class PageBuilder {
   /**
    * Creates an instance of PageBuilder
+   *
    * @memberof PageBuilder
    */
   constructor() {
@@ -66,10 +67,9 @@ class PageBuilder {
 
   /**
    * Merges precompiled .hbs templates with data to generate a Readable stream of generated .html
-   * ToDo: Switch from Through2 to native Readable stream
    *
    * @param {object} data:  Data, likely from a transformed GraphQL query, to be merged with precompiled .hbs templates
-   * @returns:              An object containing the Readable stream of generated pages, and the number of pages processed
+   * @returns:              An object containing the Readable stream of generated pages, and the number of pages and redirects processed
    * @memberof PageBuilder
    */
   async build(data) {

--- a/src/StreamUtils.js
+++ b/src/StreamUtils.js
@@ -40,15 +40,16 @@ class StreamUtils {
   /**
    * Helper function to set various additional properties on a VinylFile
    *
+   * - Vinyl provides an isDirectory() function with some odd conditions. Since we are dealing with some files with empty contents
+   *   we cannot use isDirectory().
+   *
    * @static
    * @param {*} vinylFile
    * @param {*} options
    * @returns
-   * @memberof Metafy
+   * @memberof StreamUtils
    */
   _setProperties(vinylFile, options) {
-    // ! DO NOT USE vinyl.isDirectory() as it will return false if contents = null. Issuing S3.headObject() returns nulls!!!
-
     if (vinylFile.contents) {
       // .HTML extension
       if (options.setHttpExtension) {
@@ -83,7 +84,7 @@ class StreamUtils {
    * @param {StreamReadable} destinationStream: Stream containing all the current files that exist in the destination prior to build
    * @param {*} options
    * @returns
-   * @memberof Metafy
+   * @memberof StreamUtils
    */
   parseDestinationFiles(destinationStream) {
     const self = this;
@@ -126,7 +127,7 @@ class StreamUtils {
     const transform = new Transform({
       objectMode: true,
       transform: function (vinylFile, _, done) {
-        vinylFile = self._setProperties(vinylFile, { setContentTypeHeader: true, setHash: true });
+        vinylFile = self._setProperties(vinylFile, { setContentTypeHeader: true, setHash: true, setS3Redirect: true });
         const { relative, eTag } = vinylFile;
 
         if (self.destinationReads[relative]) {
@@ -134,7 +135,7 @@ class StreamUtils {
           if (self.destinationReads[relative].eTag !== eTag) {
             // vinylFile is different than the original
             self.destinationUpdates.push(relative);
-            console.log("UPDATE:", relative, eTag);
+            console.log("UPDATE:", relative);
             done(false, vinylFile);
           } else {
             done(false);

--- a/src/StreamUtils.js
+++ b/src/StreamUtils.js
@@ -89,7 +89,7 @@ class StreamUtils {
   parseDestinationFiles(destinationStream) {
     const self = this;
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       // Parse the stream and resolve when it is done
       const writable = new Writable({
         objectMode: true,
@@ -111,7 +111,6 @@ class StreamUtils {
 
       // Setup an error handler
       writable.on("error", function (err) {
-        console.log("error");
         throw err;
       });
 
@@ -120,7 +119,10 @@ class StreamUtils {
     });
   }
 
-  // Returns a stream just the vinylFiles that need to be updated (VFS and S3)
+  /**
+   * @returns:  a stream just the vinylFiles that need to be updated (VFS and S3)
+   * @memberof StreamUtils
+   */
   filterDeployableFiles() {
     const self = this;
 

--- a/src/StreamUtils.js
+++ b/src/StreamUtils.js
@@ -129,7 +129,7 @@ class StreamUtils {
     const transform = new Transform({
       objectMode: true,
       transform: function (vinylFile, _, done) {
-        vinylFile = self._setProperties(vinylFile, { setContentTypeHeader: true, setHash: true, setS3Redirect: true });
+        vinylFile = self._setProperties(vinylFile, { setContentTypeHeader: true, setHash: true });
         const { relative, eTag } = vinylFile;
 
         if (self.destinationReads[relative]) {

--- a/src/Vinyl-s3.js
+++ b/src/Vinyl-s3.js
@@ -205,6 +205,10 @@ class VinylS3 {
           params.ContentType = file.contentType;
         }
 
+        if (file.redirect && file.redirect === 301) {
+          params.WebsiteRedirectLocation = file.targetAddress;
+        }
+
         // TODO: regardless of .html status, should we assume to set contenttype? Or do we make it config param
 
         await s3


### PR DESCRIPTION
This PR represents a minor cleanup as we prepare for 0.5.0 release. It includes:
- Renamed VinylHandlebars.js to PageBuilder.js 
- Replaced dependency on through2 with native Readable stream in PageBuilder.js
- Added support for generic 301 redirects from the data source in PageBuilder.js
- Updated Vinyl-S3.js to set the x-amz-website-redirect-location header for any files that contain the redirect property

Note: Only the Vinyl-S3 file adapter supports the deployment of 301 redirects. Apart from symlinking, the 301/302 concept is not part of OS filesystems.