### PR TITLE
Added _vinyl() private method to VinylS3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+v0.5.1 **S3+CloudFront** (2020-07-21)
+
+- Fixes issue where VinylS3 src was not creating the .path and .base properties properly.
+-
+
 v0.5.0 **S3+CloudFront** (2020-07-05)
 
 - Added support for S3+CloudFront as a deployable target

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tforster/webproducer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tforster/webproducer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "WebProducer, or simply WP, is a serverless application for publishing content to the web. It equally supports websites and web applications with a lean, streams based, architecture.",
   "author": "",
   "license": "ISC",

--- a/src/StreamUtils.js
+++ b/src/StreamUtils.js
@@ -25,6 +25,38 @@ class StreamUtils {
   }
 
   /**
+   * NOT CURRENTLY IN USE
+   *
+   * A transform stream intended to rewrite the path portion of a Vinyl file object
+   * - Was started to answer the question of moving generated scripts from scripts folder to root but abandoned in favour of
+   *   improved Vinyl file creation in VinylS3
+   * - In early testing it worked, however it rewrote the entire path rather than the path upto but not including the filename
+   *
+   * @static
+   * @param {*} newPath
+   * @returns
+   * @memberof StreamUtils
+   */
+  static mv(newPath) {
+    const transform = new Transform({
+      objectMode: true,
+      transform: function (vinylFile, _, done) {
+        console.log(`>>> Moved ${vinylFile.path} to ${newPath} for ${vinylFile.basename}`);
+        vinylFile.path = newPath;
+        done(false, vinylFile);
+      },
+    });
+
+    transform.on("error", (err) => {
+      throw new Error(err);
+    });
+
+    transform.on("finish", () => { });
+
+    return transform;
+  }
+
+  /**
    * Get the MD5 hash of the fileContents. Note that we opted for MD5 as that is already in use by S3.
    * @static
    * @param {ArrayBuffer} fileContents: Typically found as .contents from a ReadableStream where objectMode = true;

--- a/src/Vinyl-s3.js
+++ b/src/Vinyl-s3.js
@@ -8,9 +8,6 @@ const AWS = require("aws-sdk");
 const micromatch = require("micromatch");
 const Vinyl = require("vinyl");
 
-// Project dependencies
-const Utils = require("./Utils");
-
 /**
  * Implements Gulp-like dest() function to terminate a piped process by uploading the supplied Vinyl file to AWS S3
  * @class VinylS3
@@ -25,6 +22,12 @@ class VinylS3 {
     // Set objectMode true as we are processing whole Vinyl files, not chunks of a single file
     this.options = options;
     this.s3 = new AWS.S3({ region: options.region });
+
+    // https://github.com/nodejs/node-v0.x-archive/issues/3045
+    this.FS_MODES = {
+      S_IFREG: 32768, // regular file
+      S_IFDIR: 16384, // directory
+    };
   }
 
   /**
@@ -149,17 +152,8 @@ class VinylS3 {
             })
             .promise();
 
-          // Set the directory or file details, as determined by the key, in our Vinyl object params
-          if (key.match(/\/$/) > "") {
-            // Is directory so set mode and leave contents as null
-            vinylParams.stat = { mode: 16384 };
-          } else {
-            vinylParams.stat = { mode: 0 };
-            // Is file, so set contents
-            vinylParams.contents = Buffer.from(s3Object.Body);
-          }
-          // Create a new Vinyl object
-          const vinyl = new Vinyl(vinylParams);
+          // Create a Vinyl object using data obtained from the glob, the micromatch and the S3 getObject results
+          const vinyl = self._vinyl(micromatch.scan(globs[0]), key, Buffer.from(s3Object.Body));
 
           // Push the Vinyl object into the stream
           readable.push(vinyl);
@@ -171,6 +165,32 @@ class VinylS3 {
     };
 
     return readable;
+  }
+
+  /**
+   * Utility handler for easily creating Vinyl files. Currently used by _src() but should be moved to Utils and made available to
+   * a wider range of modules.
+   *
+   * @param {object} globPattern: An object containing results of the micromatch including the glob base. e.g. stage/db
+   * @param {string} globbedPath: The path. e.g. stage/db/query.graphql
+   * @param {Buffer} contents:    An optional Buffer with the file contents (would be empty for a directory)
+   * @returns:                    A fully qualified Vinyl object c/w contents (if applicable) and fsStat value
+   * @memberof VinylS3
+   */
+  _vinyl(globPattern, globbedPath, contents) {
+    // Create the file mode based on the presence of a trailing slash
+    const stat = globbedPath.match(/\/$/) > "" ? this.FS_MODES.S_IFDIR : this.FS_MODES.S_IFREG;
+
+    // Parameters object to pass to the Vinyl constructor
+    const vinylParams = {
+      cwd: "/",
+      // base: will default to cwd if it is not included
+      path: globbedPath.replace(globPattern.base, ""),
+      contents,
+      stat,
+    };
+
+    return new Vinyl(vinylParams);
   }
 
   /**


### PR DESCRIPTION
Despite the branch name, the mv method was abandoned in favour of improving a discovered flaw in VinylS3. However, the ticket was already created.

- New _vinyl() method ensures consistency of Vinyl creation including critical path and base properties
- Used the opportunity to add file mode enums
- Removed redundant requires reference that was no longer being used
- Created StreamUtils.mv() but did not end up using it.
- StreamUtils.mv() aas potential future value and is being left in