### PR TITLE
#729 Split PageBuilder into HTML and non-HTML streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+v0.7.0 **Separated non-HTML files from HTML minifier** (2020-08-01)
+
+- non-HTML files such as robots.txt, sitemap.xml and feed.xml were being sent through the HTML minifier along with regular HTML files with unexpected results. This has feature bump sees the separation of HTML and non-HTML before HTML minification occurs. Note that non-HTML files are _not_ minified at all now.
+
 v0.6.0 **Static JSON Files** (2020-07-26)
 
 Breaking changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tforster/webproducer",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.0",
   "description": "WebProducer, or simply WP, is a serverless application for publishing content to the web. It equally supports websites and web applications with a lean, streams based, architecture.",
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tforster/webproducer.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tforster/webproducer",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "WebProducer, or simply WP, is a serverless application for publishing content to the web. It equally supports websites and web applications with a lean, streams based, architecture.",
   "author": "",
   "license": "ISC",

--- a/src/MergeStream.js
+++ b/src/MergeStream.js
@@ -41,7 +41,7 @@ class MergeStream {
 
     // Set up the on end handler for the sourceStream
     inputStream.on("end", () => {
-      console.log(`>>> Unmerged ${inputStream.name}`);
+      console.log(`>>> Merged ${inputStream.name}`);
 
       // Decrement the input streams until none remain and we can manually force end() on the outputStream
       self.inputStreams = self.inputStreams.filter((s) => s !== inputStream);
@@ -57,7 +57,7 @@ class MergeStream {
 
     // Immediately start reading the contents of this sourceStream and piping to the outputStream
     inputStream.pipe(this.outputStream, { end: false });
-    console.log(`>>> Merged ${inputStream.name}`);
+    //console.log(`>>> Merged ${inputStream.name}`);
   }
 }
 


### PR DESCRIPTION
-  Added second readable stream to PageBuilder so we now track HTML and non-HTML files
- Added a files counter to PageBuilder to report on built pages vs built files
- Index.js adjusted to accommodate modified PageBuilder response
- Index.js routes the HTML stream to the HTML minification but not file stream
- The new file stream along with the minified HTML stream are merged to output in index.js
- Removed one redundant line of output in MergeStream.js