### PR TITLE
Support multiple template sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,21 @@ Each workspace/package maintains its own `CHANGELOG.md` for package-specific cha
 - [services/gilbert-cli/CHANGELOG.md](./services/gilbert-cli/CHANGELOG.md)
 - [services/gilbert-file/CHANGELOG.md](./services/gilbert-file/CHANGELOG.md)
 
-## [v1.0.0-rc.1](https://github.com/tforster/gilbert/compare/v1.0.0-beta.5...v1.0.0-rc.1) - 2025-06-09
+## [v1.0.0-rc.2](https://github.com/tforster/gilbert/compare/v1.0.0-rc.1...v1.0.0-rc.2) - 2026-04-07
+
+### Added
+
+- **Multi-source template loading** — `TemplatePipeline` now accepts a `ReadableStream | ReadableStream[]` for the `templates` option. All sources are loaded concurrently via `Promise.all()` and merged into a single in-memory template map before rendering begins. Load time equals the slowest individual source, not their sum.
+- **Multi-source static files** — the `staticFiles` option in `Gilbert` now accepts a `ReadableStream | ReadableStream[]`. Each stream is processed through its own `StaticFilesPipeline` instance, all running concurrently.
+- **Template collision detection** — when the same template key appears in more than one template source, Gilbert throws a descriptive error (`Template collision: "x.hbs" is defined in multiple template sources`) rather than silently overwriting. The collision check is atomic (synchronous slot reservation before the async read) to prevent race conditions under concurrent stream loading.
+- **Unified test summary** — `scripts/test.js` wraps the workspace test runner, streams output in real time, and prints a consolidated pass/fail total across all packages at the end.
+
+### Changed
+
+- All test suites across the monorepo (`gilbert`, `gilbert-fs`, `gilbert-github`) now write output to unique per-test subdirectories under `os.tmpdir()` rather than a shared `tests/dist/` folder, eliminating intermittent failures caused by concurrent test runs.
+- Root `package.json` `test` script updated to invoke `node scripts/test.js` for the unified summary output.
+
+## [v1.0.0-rc.1](https://github.com/tforster/gilbert/compare/v1.0.0-beta.5...v1.0.0-rc.1) - 2026-04-06
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,12 @@ Each workspace/package maintains its own `CHANGELOG.md` for package-specific cha
 - **Multi-source template loading** — `TemplatePipeline` now accepts a `ReadableStream | ReadableStream[]` for the `templates` option. All sources are loaded concurrently via `Promise.all()` and merged into a single in-memory template map before rendering begins. Load time equals the slowest individual source, not their sum.
 - **Multi-source static files** — the `staticFiles` option in `Gilbert` now accepts a `ReadableStream | ReadableStream[]`. Each stream is processed through its own `StaticFilesPipeline` instance, all running concurrently.
 - **Template collision detection** — when the same template key appears in more than one template source, Gilbert throws a descriptive error (`Template collision: "x.hbs" is defined in multiple template sources`) rather than silently overwriting. The collision check is atomic (synchronous slot reservation before the async read) to prevent race conditions under concurrent stream loading.
-- **Unified test summary** — `scripts/test.js` wraps the workspace test runner, streams output in real time, and prints a consolidated pass/fail total across all packages at the end.
+- **Unified test summary** — `devops/test.js` wraps the workspace test runner, streams output in real time, and prints a consolidated pass/fail total across all packages at the end.
 
 ### Changed
 
 - All test suites across the monorepo (`gilbert`, `gilbert-fs`, `gilbert-github`) now write output to unique per-test subdirectories under `os.tmpdir()` rather than a shared `tests/dist/` folder, eliminating intermittent failures caused by concurrent test runs.
-- Root `package.json` `test` script updated to invoke `node scripts/test.js` for the unified summary output.
+- Root `package.json` `test` script updated to invoke `node devops/test.js` for the unified summary output.
 
 ## [v1.0.0-rc.1](https://github.com/tforster/gilbert/compare/v1.0.0-beta.5...v1.0.0-rc.1) - 2026-04-06
 

--- a/README.md
+++ b/README.md
@@ -95,13 +95,17 @@ import GilbertFS from "@tforster/gilbert-fs";
 
 const dataAdapter = new GilbertFS({ base: "./src/data" });
 const templatesAdapter = new GilbertFS({ base: "./src/templates" });
+const componentsAdapter = new GilbertFS({ base: "./src/components" });
 
 const gilbert = new Gilbert({
   data: { source: dataAdapter.read("**/*.json") },
-  templates: templatesAdapter.read("**/*.hbs"),
+  // Accept an array of streams to load templates from multiple sources.
+  // All sources are merged into a single in-memory template map before rendering begins.
+  templates: [templatesAdapter.read("**/*.hbs"), componentsAdapter.read("**/*.hbs")],
   scripts: ["./src/scripts/main.js"],
   stylesheets: ["./src/stylesheets/main.css"],
-  staticFiles: new GilbertFS({ base: "./src/files" }).read("**/*"),
+  // staticFiles also accepts an array — each stream is processed independently.
+  staticFiles: [new GilbertFS({ base: "./src/files" }).read("**/*"), new GilbertFS({ base: "./src/assets" }).read("**/*")],
 });
 
 await gilbert.compile();

--- a/devops/test.js
+++ b/devops/test.js
@@ -1,0 +1,62 @@
+/**
+ * @description Root test runner that executes all workspace tests sequentially and prints a
+ * unified pass/fail summary at the end. Output is streamed in real-time; the process exits with
+ * the same code as the underlying npm workspace runner.
+ */
+import { spawn } from "node:child_process";
+
+let totalPass = 0;
+let totalFail = 0;
+
+/**
+ * Process one line of test runner output: print it and accumulate pass/fail counts.
+ * @param {string} line
+ */
+function processLine(line) {
+  process.stdout.write(line + "\n");
+
+  // Node.js built-in test runner emits: "ℹ pass N" and "ℹ fail N"
+  if (line.includes("ℹ pass ")) {
+    totalPass += parseInt(line.trim().split(/\s+/).pop(), 10) || 0;
+  } else if (line.includes("ℹ fail ")) {
+    totalFail += parseInt(line.trim().split(/\s+/).pop(), 10) || 0;
+  }
+}
+
+// --workspaces runs the test script in each workspace package only, not in the root.
+// --workspace-concurrency=1 keeps output readable and prevents dist directory collisions.
+const child = spawn("npm", ["run", "test", "--workspaces", "--if-present", "--workspace-concurrency=1"], {
+  stdio: ["inherit", "pipe", "pipe"],
+  shell: false,
+  env: { ...process.env, FORCE_COLOR: "1" },
+});
+
+// Buffer incomplete lines so split output chunks are handled correctly
+let stdoutRemainder = "";
+let stderrRemainder = "";
+
+child.stdout.on("data", (chunk) => {
+  const text = stdoutRemainder + chunk.toString();
+  const lines = text.split("\n");
+  stdoutRemainder = lines.pop();
+  lines.forEach(processLine);
+});
+
+child.stderr.on("data", (chunk) => {
+  const text = stderrRemainder + chunk.toString();
+  const lines = text.split("\n");
+  stderrRemainder = lines.pop();
+  lines.forEach((line) => process.stderr.write(line + "\n"));
+});
+
+child.on("close", (code) => {
+  // Flush any remaining partial line
+  if (stdoutRemainder) processLine(stdoutRemainder);
+  if (stderrRemainder) process.stderr.write(stderrRemainder + "\n");
+
+  const bar = "─".repeat(44);
+  const status = totalFail > 0 ? `${totalPass} passed, ${totalFail} FAILED` : `${totalPass} passed`;
+  process.stdout.write(`\n${bar}\n  Total: ${status}\n${bar}\n`);
+
+  process.exit(code ?? 0);
+});

--- a/devops/test.js
+++ b/devops/test.js
@@ -25,9 +25,9 @@ function processLine(line) {
 
 // --workspaces runs the test script in each workspace package only, not in the root.
 // --workspace-concurrency=1 keeps output readable and prevents dist directory collisions.
-const child = spawn("npm", ["run", "test", "--workspaces", "--if-present", "--workspace-concurrency=1"], {
+const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+const child = spawn(npmCmd, ["run", "test", "--workspaces", "--if-present", "--workspace-concurrency=1"], {
   stdio: ["inherit", "pipe", "pipe"],
-  shell: false,
   env: { ...process.env, FORCE_COLOR: "1" },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7366,7 +7366,7 @@
       "version": "1.0.0",
       "dependencies": {
         "commander": "^14.0.2",
-        "gilbert": "@tforster/gilbert@1.0.0-beta.5",
+        "gilbert": "@tforster/gilbert@1.0.0-rc.1",
         "vinyl-fs": "4.0.2"
       },
       "bin": {
@@ -7374,6 +7374,9 @@
       }
     },
     "services/gilbert-cli/@tforster/gilbert@1.0.0-beta.5": {},
+    "services/gilbert-cli/@tforster/gilbert@1.0.0-rc.1": {
+      "extraneous": true
+    },
     "services/gilbert-cli/node_modules/gilbert": {
       "resolved": "services/gilbert-cli/@tforster/gilbert@1.0.0-beta.5",
       "link": true

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint:fix": "oxlint --fix",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
-    "test": "npm run test --workspaces --if-present --workspace-concurrency=1",
+    "test": "node devops/test.js",
     "test:all": "npm run test && npm run test:performance",
     "test:performance": "node --test tests/performance/performance.test.js"
   },

--- a/services/gilbert-fs/tests/gilbert-fs-write.test.js
+++ b/services/gilbert-fs/tests/gilbert-fs-write.test.js
@@ -1,40 +1,33 @@
 // Gilbert-FS Write Functionality Tests
 import { test, describe } from "node:test";
 import assert from "node:assert";
-import { readFile, rm, stat, readdir } from "node:fs/promises";
+import { readFile, mkdir, stat, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
 // Project dependencies
 import GilbertFS from "../lib/index.js";
 import GilbertFile from "@tforster/gilbert-file";
 
-// Test paths
-const TEST_SRC_DIR = "../../tests/src/files";
-const TEST_DIST_DIR = "./tests/dist";
+// Each test gets its own isolated tmp subdirectory — no shared state between tests
+let testIndex = 0;
+const makeDistDir = async () => {
+  const dir = path.join(tmpdir(), `gilbert-fs-write-${++testIndex}`);
+  await mkdir(dir, { recursive: true });
+  return dir;
+};
 
 describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
   // Helper function to create test GilbertFile objects
   function createTestFile(relativePath, content, options = {}) {
-    const fullPath = path.resolve(TEST_SRC_DIR, relativePath);
+    const srcBase = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../../tests/src/files");
+    const fullPath = path.resolve(srcBase, relativePath);
     return new GilbertFile({
       path: fullPath,
-      base: path.resolve(TEST_SRC_DIR),
+      base: srcBase,
       contents: typeof content === "string" ? new TextEncoder().encode(content) : content,
       ...options,
     });
-  }
-
-  // Helper function to clean dist directory
-  async function cleanDist() {
-    try {
-      await rm(TEST_DIST_DIR, { recursive: true, force: true });
-    } catch (error) {
-      // Ignore ENOENT errors (directory doesn't exist)
-      if (error.code !== "ENOENT") {
-        throw error;
-      }
-    }
-    return TEST_DIST_DIR;
   }
 
   // Helper function to write files to stream
@@ -51,7 +44,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should create WritableStream with write method", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
     const stream = fs.write(distDir);
 
     assert.ok(stream instanceof WritableStream, "Should return WritableStream");
@@ -59,7 +52,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should write single file to filesystem", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     const testFile = createTestFile("test.txt", "Hello, World!");
     const stream = fs.write(distDir);
@@ -73,7 +66,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should write multiple files to filesystem", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     const files = [
       createTestFile("file1.txt", "Content 1"),
@@ -95,7 +88,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should create nested directories as needed", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     const nestedFile = createTestFile("deeply/nested/directory/file.txt", "Nested content");
     const stream = fs.write(distDir);
@@ -110,7 +103,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should handle files with null contents (empty files)", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     // Create empty file with explicit stat info to indicate it's a file, not a directory
     const emptyFile = createTestFile("empty.txt", null, {
@@ -133,7 +126,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should handle files with ReadableStream contents", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     // Create a ReadableStream with test content
     const chunks = ["Hello, ", "streaming ", "world!"];
@@ -161,7 +154,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should preserve file structure from relative paths", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     const files = [
       createTestFile("root.txt", "root content"),
@@ -184,7 +177,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should handle concurrent write operations", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     // Create multiple write operations concurrently
     const operations = [];
@@ -206,7 +199,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should handle different file types correctly", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     const files = [
       createTestFile("text.txt", "Plain text content"),
@@ -237,7 +230,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should handle large files efficiently", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     // Create a large file (1MB of content)
     const largeContent = "A".repeat(1024 * 1024);
@@ -260,7 +253,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should handle binary file contents", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     // Create binary content
     const binaryData = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]); // PNG header
@@ -281,7 +274,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should handle backpressure correctly", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     // Create many files to test backpressure
     const files = [];
@@ -323,7 +316,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should preserve file timestamps when possible", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     // Create file with custom stat information
     const customStat = {
@@ -348,7 +341,7 @@ describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {
 
   test("should handle files with complex relative paths", async () => {
     const fs = new GilbertFS();
-    const distDir = await cleanDist();
+    const distDir = await makeDistDir();
 
     const files = [
       createTestFile("../outside.txt", "outside content"),

--- a/services/gilbert-fs/tests/gilbert-fs-write.test.js
+++ b/services/gilbert-fs/tests/gilbert-fs-write.test.js
@@ -1,7 +1,7 @@
 // Gilbert-FS Write Functionality Tests
 import { test, describe } from "node:test";
 import assert from "node:assert";
-import { readFile, mkdir, stat, readdir } from "node:fs/promises";
+import { readFile, mkdtemp, stat, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -9,12 +9,9 @@ import path from "node:path";
 import GilbertFS from "../lib/index.js";
 import GilbertFile from "@tforster/gilbert-file";
 
-// Each test gets its own isolated tmp subdirectory — no shared state between tests
-let testIndex = 0;
+// Each test gets its own isolated tmp subdirectory with a random suffix — no shared state between tests
 const makeDistDir = async () => {
-  const dir = path.join(tmpdir(), `gilbert-fs-write-${++testIndex}`);
-  await mkdir(dir, { recursive: true });
-  return dir;
+  return await mkdtemp(path.join(tmpdir(), "gilbert-fs-write-"));
 };
 
 describe("GilbertFS Write Operations", { concurrency: 1 }, async () => {

--- a/services/gilbert-github/tests/github-files.test.js
+++ b/services/gilbert-github/tests/github-files.test.js
@@ -1,14 +1,20 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { resolve } from "node:path";
-import { readdir, stat, readFile, mkdir, rm } from "node:fs/promises";
+import { readdir, stat, readFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
 
 // Gilbert and dependencies
 import Gilbert from "@tforster/gilbert";
 import GilbertGitHub from "../lib/index.js";
 
-// Test paths for output
-const distDir = resolve("./tests/dist");
+// Each test gets its own isolated tmp subdirectory — no shared state between tests
+let testIndex = 0;
+const makeDistDir = async () => {
+  const dir = resolve(tmpdir(), `gilbert-github-${++testIndex}`);
+  await mkdir(dir, { recursive: true });
+  return dir;
+};
 
 // Test configuration - using the real StopTheParty repository
 const testRepo = "Stop-The-Party/www.stoptheparty.ca"; // Real repo with .hbs files
@@ -68,10 +74,7 @@ describe("Gilbert GitHub Files Pipeline", { concurrency: 1 }, () => {
       return;
     }
 
-    // Clean output directory
-    await rm(distDir, { recursive: true, force: true });
-
-    // Create adapter instance for specific repo and branch
+    const distDir = await makeDistDir();
     const githubAdapter = createTestAdapter();
 
     // Create Gilbert instance
@@ -87,8 +90,7 @@ describe("Gilbert GitHub Files Pipeline", { concurrency: 1 }, () => {
     // Compile through Gilbert
     await gilbert.compile(params);
 
-    // Create output directory and stream to destination
-    await mkdir(distDir, { recursive: true });
+    // Stream to destination
     await gilbert.stream.pipeTo(githubAdapter.write(distDir));
 
     // Verify output files exist
@@ -112,9 +114,7 @@ describe("Gilbert GitHub Files Pipeline", { concurrency: 1 }, () => {
       return;
     }
 
-    // Clean output directory
-    await rm(distDir, { recursive: true, force: true });
-
+    const distDir = await makeDistDir();
     const githubAdapter = createTestAdapter();
 
     // Create Gilbert instance for array pattern test
@@ -158,37 +158,33 @@ describe("Gilbert GitHub Files Pipeline", { concurrency: 1 }, () => {
       return;
     }
 
-    // Clean output directory
-    await rm(distDir, { recursive: true, force: true });
-
     // Create two adapters for different branches (like in real usage)
     const templatesAdapter = createTestAdapter({ branch: "main" });
     const contentAdapter = createTestAdapter({ branch: "content" });
 
     // Test templates from main branch
+    const dist1 = await makeDistDir();
     const gilbert1 = new Gilbert({ debug: true });
     const templateParams = {
       staticFiles: templatesAdapter.read(["/**/*.hbs"]),
     };
 
     await gilbert1.compile(templateParams);
-    await gilbert1.stream.pipeTo(templatesAdapter.write(distDir));
+    await gilbert1.stream.pipeTo(templatesAdapter.write(dist1));
 
-    const templateFiles = await getAllFiles(distDir);
-
-    // Clean for content test
-    await rm(distDir, { recursive: true, force: true });
+    const templateFiles = await getAllFiles(dist1);
 
     // Test content from content branch
+    const dist2 = await makeDistDir();
     const gilbert2 = new Gilbert({ debug: true });
     const contentParams = {
       staticFiles: contentAdapter.read(["/**/*.json"]),
     };
 
     await gilbert2.compile(contentParams);
-    await gilbert2.stream.pipeTo(contentAdapter.write(distDir));
+    await gilbert2.stream.pipeTo(contentAdapter.write(dist2));
 
-    const contentFiles = await getAllFiles(distDir);
+    const contentFiles = await getAllFiles(dist2);
 
     // Both should work independently
     assert.ok(templateFiles.length >= 0, "Should handle templates branch");
@@ -203,9 +199,7 @@ describe("Gilbert GitHub Files Pipeline", { concurrency: 1 }, () => {
       return;
     }
 
-    // Clean output directory
-    await rm(distDir, { recursive: true, force: true });
-
+    const distDir = await makeDistDir();
     // Test with a different branch (if available)
     const mainAdapter = createTestAdapter({ branch: "main" });
 
@@ -235,28 +229,26 @@ describe("Gilbert GitHub Files Pipeline", { concurrency: 1 }, () => {
     const githubAdapter = createTestAdapter();
 
     // Test single pattern
-    await rm(distDir, { recursive: true, force: true });
-
+    const dist2 = await makeDistDir();
     const gilbert2 = new Gilbert({ debug: true });
     const singlePatternParams = {
       staticFiles: githubAdapter.read("**/*.json"),
     };
 
     await gilbert2.compile(singlePatternParams);
-    await gilbert2.stream.pipeTo(githubAdapter.write(distDir));
-    const singlePatternFiles = await getAllFiles(distDir);
+    await gilbert2.stream.pipeTo(githubAdapter.write(dist2));
+    const singlePatternFiles = await getAllFiles(dist2);
 
     // Test array with single pattern
-    await rm(distDir, { recursive: true, force: true });
-
+    const dist3 = await makeDistDir();
     const gilbert3 = new Gilbert({ debug: true });
     const arrayPatternParams = {
       staticFiles: githubAdapter.read(["**/*.json"]),
     };
 
     await gilbert3.compile(arrayPatternParams);
-    await gilbert3.stream.pipeTo(githubAdapter.write(distDir));
-    const arrayPatternFiles = await getAllFiles(distDir);
+    await gilbert3.stream.pipeTo(githubAdapter.write(dist3));
+    const arrayPatternFiles = await getAllFiles(dist3);
 
     // Should produce same results
     assert.equal(
@@ -274,9 +266,7 @@ describe("Gilbert GitHub Files Pipeline", { concurrency: 1 }, () => {
       return;
     }
 
-    // Clean output directory
-    await rm(distDir, { recursive: true, force: true });
-
+    const distDir = await makeDistDir();
     const githubAdapter = createTestAdapter();
 
     const gilbert = new Gilbert({
@@ -303,9 +293,7 @@ describe("Gilbert GitHub Files Pipeline", { concurrency: 1 }, () => {
       return;
     }
 
-    // Clean output directory
-    await rm(distDir, { recursive: true, force: true });
-
+    const distDir = await makeDistDir();
     const githubAdapter = createTestAdapter();
 
     const gilbert = new Gilbert({

--- a/services/gilbert-github/tests/github-files.test.js
+++ b/services/gilbert-github/tests/github-files.test.js
@@ -1,19 +1,16 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { resolve } from "node:path";
-import { readdir, stat, readFile, mkdir } from "node:fs/promises";
+import { readdir, stat, readFile, mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 
 // Gilbert and dependencies
 import Gilbert from "@tforster/gilbert";
 import GilbertGitHub from "../lib/index.js";
 
-// Each test gets its own isolated tmp subdirectory — no shared state between tests
-let testIndex = 0;
+// Each test gets its own isolated tmp subdirectory with a random suffix — no shared state between tests
 const makeDistDir = async () => {
-  const dir = resolve(tmpdir(), `gilbert-github-${++testIndex}`);
-  await mkdir(dir, { recursive: true });
-  return dir;
+  return await mkdtemp(resolve(tmpdir(), "gilbert-github-"));
 };
 
 // Test configuration - using the real StopTheParty repository

--- a/services/gilbert/lib/SimpleHtmlMinifier.js
+++ b/services/gilbert/lib/SimpleHtmlMinifier.js
@@ -68,7 +68,7 @@ class SimpleHtmlMinifier {
 
     // Basic JS minification within <script> tags (very conservative)
     if (config.minifyJS) {
-      result = result.replace(/<script[^>]*>([\s\S]*?)<\/script>/gi, (match, js) => {
+      result = result.replace(/<script\b[^>]*>([\s\S]*?)<\/script\b[^>]*>/gi, (match, js) => {
         // Only do very safe JS minification
         const minifiedJS = js
           .replace(/\/\/.*$/gm, "") // Remove single-line comments

--- a/services/gilbert/lib/TemplatePipeline.js
+++ b/services/gilbert/lib/TemplatePipeline.js
@@ -16,21 +16,21 @@ class TemplatePipeline {
   // Private properties
   /** @type {ReadableStream} */
   #readableDataStream;
-  /** @type {ReadableStream} */
-  #readableTemplatesStream;
+  /** @type {ReadableStream[]} */
+  #readableTemplatesStreams;
   #templates = {};
   #logger;
 
   /**
    * Creates an instance of TemplatePipeline.
    * @param {*} options
-   * @param {*} readableDataStream
-   * @param {*} readableTemplatesStream
+   * @param {ReadableStream} readableDataStream
+   * @param {ReadableStream|ReadableStream[]} readableTemplatesStream - One or more template streams
    * @memberof TemplatePipeline
    */
   constructor(options, readableDataStream, readableTemplatesStream) {
     this.#readableDataStream = readableDataStream;
-    this.#readableTemplatesStream = readableTemplatesStream;
+    this.#readableTemplatesStreams = Array.isArray(readableTemplatesStream) ? readableTemplatesStream : [readableTemplatesStream];
     // Enable debug logging when the GILBERT_DEBUG global is set (WinterCG-compatible)
     this.#logger = createLogger(globalThis.GILBERT_DEBUG === "true");
   }
@@ -125,24 +125,36 @@ class TemplatePipeline {
    * @memberof TemplatePipeline
    */
   async #loadTemplates() {
-    // Create a collector function for processing Web API streams
-    const collector = WebStreamUtils.createFileCollector(async (file) => {
-      // Use file.relative directly as the template key since GilbertFS base path handling
-      // ensures the relative path is already correctly calculated from the base
-      if (!file.isDirectory()) {
-        const templateKey = file.relative;
+    // Fan-out over all template streams concurrently. Load time = max(individual stream
+    // durations), not their sum — a strict performance win for multi-source scenarios.
+    await Promise.all(
+      this.#readableTemplatesStreams.map((stream) => {
+        const collector = WebStreamUtils.createFileCollector(async (file) => {
+          // Use file.relative directly as the template key since GilbertFS base path handling
+          // ensures the relative path is already correctly calculated from the base
+          if (!file.isDirectory()) {
+            const templateKey = file.relative;
 
-        // Get the content of the template
-        const content = await file.toString();
+            // Collision guard: reserve the slot synchronously before awaiting file content.
+            // This prevents a race where two concurrent streams both pass the check before
+            // either writes, which would silently produce non-deterministic last-wins behaviour.
+            if (templateKey in this.#templates) {
+              throw new Error(
+                `Template collision: "${templateKey}" is defined in multiple template sources. Each template key must be unique across all sources.`
+              );
+            }
+            this.#templates[templateKey] = null; // reserve slot
 
-        // Compile as a template (Gilbert's approach for 10 years)
-        this.#templates[templateKey] = handlebars.compile(content);
+            // Get the content of the template
+            const content = await file.toString();
 
-        // Also register as partial with raw content (needed for newer Handlebars)
-      }
-    });
-    // Pipe the templates stream to the collector to load all templates into memory
-    await this.#readableTemplatesStream.pipeTo(collector.stream);
+            // Compile as a template (Gilbert's approach for 10 years)
+            this.#templates[templateKey] = handlebars.compile(content);
+          }
+        });
+        return stream.pipeTo(collector.stream);
+      })
+    );
 
     // Set partials to templates (Gilbert's 10-year tradition)
     // This allows templates to reference each other via {{> templateName }}

--- a/services/gilbert/lib/index.js
+++ b/services/gilbert/lib/index.js
@@ -253,17 +253,19 @@ class Gilbert {
       }
     }
 
-    // Static files processing
-    if (this.#streams.static || this.#streams.staticFiles) {
-      const staticFilesPipeline = new StaticFilesPipeline();
+    // Static files processing — accepts a single ReadableStream or an array of ReadableStreams
+    const staticInput = this.#streams.static || this.#streams.staticFiles;
+    if (staticInput) {
+      const staticStreams = Array.isArray(staticInput) ? staticInput : [staticInput];
 
-      // Handle both new 'static' and legacy 'staticFiles' names
-      const staticStream = this.#streams.static || this.#streams.staticFiles;
-      const staticReader = staticStream.pipeThrough(staticFilesPipeline.transformStream);
-      pipelinePromises.push(this.#processPipeline(staticReader, "StaticFiles"));
+      for (const staticStream of staticStreams) {
+        const staticFilesPipeline = new StaticFilesPipeline();
+        const staticReader = staticStream.pipeThrough(staticFilesPipeline.transformStream);
+        pipelinePromises.push(this.#processPipeline(staticReader, "StaticFiles"));
+      }
 
       if (this.#options.debug) {
-        logger.debug("Static files pipeline started");
+        logger.debug(`Static files pipeline started (${staticStreams.length} stream(s))`);
       }
     }
 

--- a/services/gilbert/tests/full.test.js
+++ b/services/gilbert/tests/full.test.js
@@ -5,7 +5,8 @@
 
 import { test, before } from "node:test";
 import assert from "node:assert";
-import { rm } from "node:fs/promises";
+import { rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { existsSync } from "node:fs";
 
@@ -14,7 +15,7 @@ import GilbertFS from "@tforster/gilbert-fs";
 
 const testDir = new URL(".", import.meta.url).pathname;
 const srcDir = resolve(testDir, "../../../tests/src");
-const distDir = join(testDir, "dist");
+const distDir = join(tmpdir(), "gilbert-full");
 
 // Create GilbertFS adapter instances
 const dataAdapter = new GilbertFS({ base: resolve(srcDir, "data") });
@@ -23,9 +24,8 @@ const staticAdapter = new GilbertFS({ base: srcDir });
 const outputAdapter = new GilbertFS();
 
 before(async () => {
-  if (existsSync(distDir)) {
-    await rm(distDir, { recursive: true, force: true });
-  }
+  await rm(distDir, { recursive: true, force: true });
+  await mkdir(distDir, { recursive: true });
 });
 
 test("Gilbert full website build", async () => {

--- a/services/gilbert/tests/middleware.test.js
+++ b/services/gilbert/tests/middleware.test.js
@@ -2,6 +2,7 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { resolve } from "node:path";
 import { readdir, readFile, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { marked } from "marked";
 
@@ -22,15 +23,11 @@ const templatesAdapter = new GilbertFS({ base: templatesDir });
 const outputAdapter = new GilbertFS();
 
 await describe("Gilbert Data Middleware", { concurrency: 1 }, () => {
+  const distDir = path.join(tmpdir(), "gilbert-middleware");
   const cleanDist = async () => {
-    const distPath = path.join(__dirname, "dist");
-    try {
-      await rm(distPath, { recursive: true, force: true });
-      await mkdir(distPath, { recursive: true });
-    } catch {
-      await mkdir(distPath, { recursive: true });
-    }
-    return distPath;
+    await rm(distDir, { recursive: true, force: true });
+    await mkdir(distDir, { recursive: true });
+    return distDir;
   };
   test("should process data through middleware before templates", async () => {
     const testDistDir = await cleanDist();

--- a/services/gilbert/tests/scripts.test.js
+++ b/services/gilbert/tests/scripts.test.js
@@ -2,25 +2,22 @@ import { test, describe } from "node:test";
 import assert from "node:assert";
 import { existsSync } from "node:fs";
 import { readdir, readFile, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import Gilbert from "../lib/index.js";
 import GilbertFS from "@tforster/gilbert-fs";
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 const rootSrcDir = path.resolve(__dirname, "../../../tests/src");
+const distDir = path.join(tmpdir(), "gilbert-scripts");
 
 // Create GilbertFS adapter instance
 const fsAdapter = new GilbertFS();
 
 await describe("Gilbert Scripts Pipeline", { concurrency: 1 }, () => {
   const cleanDist = async () => {
-    const distPath = path.join(__dirname, "dist");
-    try {
-      await rm(distPath, { recursive: true, force: true });
-      await mkdir(distPath, { recursive: true });
-    } catch {
-      await mkdir(distPath, { recursive: true });
-    }
+    await rm(distDir, { recursive: true, force: true });
+    await mkdir(distDir, { recursive: true });
   };
 
   test("should process scripts with StopTheParty app structure", async () => {
@@ -39,16 +36,15 @@ await describe("Gilbert Scripts Pipeline", { concurrency: 1 }, () => {
     );
 
     // Compile and pipe Gilbert output to filesystem destination using adapter
-    await (await gilbert.compile()).pipeTo(fsAdapter.write(path.join(__dirname, "dist")));
+    await (await gilbert.compile()).pipeTo(fsAdapter.write(distDir));
 
-    const outputDir = path.join(__dirname, "dist");
-    assert.ok(existsSync(outputDir), "Output directory should exist");
+    assert.ok(existsSync(distDir), "Output directory should exist");
 
-    const files = await readdir(outputDir);
+    const files = await readdir(distDir);
     const jsFiles = files.filter((file) => file.endsWith(".js"));
     assert.ok(jsFiles.length > 0, "At least one JavaScript file should be generated");
 
-    const mainJsPath = path.join(outputDir, "main.js");
+    const mainJsPath = path.join(distDir, "main.js");
     assert.ok(existsSync(mainJsPath), "main.js should exist");
 
     const content = await readFile(mainJsPath, "utf8");
@@ -75,19 +71,18 @@ await describe("Gilbert Scripts Pipeline", { concurrency: 1 }, () => {
     );
 
     // Compile and pipe Gilbert output to filesystem destination using adapter
-    await (await gilbert.compile()).pipeTo(fsAdapter.write(path.join(__dirname, "dist")));
+    await (await gilbert.compile()).pipeTo(fsAdapter.write(distDir));
 
-    const outputDir = path.join(__dirname, "dist");
-    assert.ok(existsSync(outputDir), "Output directory should exist");
+    assert.ok(existsSync(distDir), "Output directory should exist");
 
     // Get files immediately after this specific test run
-    const files = await readdir(outputDir);
+    const files = await readdir(distDir);
     const jsFiles = files.filter((file) => file.endsWith(".js"));
     assert.ok(jsFiles.length > 0, "At least one JavaScript file should be generated");
 
     // Should not have sourcemap files since sourcemap: false
     // Note: This test may see files from previous test runs, so we check the JS content instead
-    const mainJsPath = path.join(outputDir, "main.js");
+    const mainJsPath = path.join(distDir, "main.js");
     const content = await readFile(mainJsPath, "utf8");
 
     // Verify this is the unminified version by checking for sourcemap reference

--- a/services/gilbert/tests/static-files.test.js
+++ b/services/gilbert/tests/static-files.test.js
@@ -2,6 +2,7 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { resolve } from "node:path";
 import { readdir, stat, readFile, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 
 // Gilbert and dependencies
 import Gilbert from "../lib/index.js";
@@ -11,7 +12,10 @@ import GilbertFS from "@tforster/gilbert-fs";
 const __dirname = resolve(new URL(".", import.meta.url).pathname);
 const srcDir = resolve(__dirname, "../../../tests/src");
 const filesDir = resolve(srcDir, "files");
-const distDir = resolve(__dirname, "dist");
+
+// Each test gets its own isolated tmp subdirectory — no shared state between tests
+let testIndex = 0;
+const makeDistDir = () => resolve(tmpdir(), `gilbert-static-files-${++testIndex}`);
 
 // Create GilbertFS adapter instance for testing new constructor pattern
 const fsAdapter = new GilbertFS({ base: srcDir });
@@ -57,8 +61,9 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
   // });
 
   test("should process static files through Gilbert pipeline", async () => {
-    // Clean output directory
-    await rm(distDir, { recursive: true, force: true });
+    // Each test gets a fresh, isolated tmp subdirectory
+    const distDir = makeDistDir();
+    await mkdir(distDir, { recursive: true });
 
     // Get expected file count from source directory
     const inputFiles = await getAllFiles(filesDir);
@@ -142,8 +147,9 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
   });
 
   test("should preserve file structure and paths", async () => {
-    // Clean output directory
-    await rm(distDir, { recursive: true, force: true });
+    // Each test gets a fresh, isolated tmp subdirectory
+    const distDir = makeDistDir();
+    await mkdir(distDir, { recursive: true });
 
     const gilbert = new Gilbert(
       {
@@ -175,8 +181,9 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
   });
 
   test("should pass through files without modification", async () => {
-    // Clean output directory
-    await rm(distDir, { recursive: true, force: true });
+    // Each test gets a fresh, isolated tmp subdirectory
+    const distDir = makeDistDir();
+    await mkdir(distDir, { recursive: true });
 
     const gilbert = new Gilbert(
       {
@@ -202,8 +209,9 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
   });
 
   test("should handle array patterns to filter specific file types", async () => {
-    // Clean output directory
-    await rm(distDir, { recursive: true, force: true });
+    // Each test gets a fresh, isolated tmp subdirectory; sub-phases use sibling dirs
+    const distDir = makeDistDir();
+    await mkdir(distDir, { recursive: true });
 
     // Create Gilbert instance for array pattern test
     const gilbert1 = new Gilbert(
@@ -241,7 +249,8 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
     }
 
     // Test single pattern vs array pattern should be equivalent for same pattern
-    await rm(distDir, { recursive: true, force: true });
+    const distDir2 = makeDistDir();
+    await mkdir(distDir2, { recursive: true });
 
     // Create new Gilbert instance for single pattern test
     const gilbert2 = new Gilbert(
@@ -253,12 +262,13 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
       }
     );
 
-    await (await gilbert2.compile()).pipeTo(fsAdapter.write(distDir));
+    await (await gilbert2.compile()).pipeTo(fsAdapter.write(distDir2));
 
-    const singlePatternFiles = await getAllFiles(distDir);
+    const singlePatternFiles = await getAllFiles(distDir2);
 
     // Clean and test array with single pattern
-    await rm(distDir, { recursive: true, force: true });
+    const distDir3 = makeDistDir();
+    await mkdir(distDir3, { recursive: true });
 
     // Create new Gilbert instance for array pattern test
     const gilbert3 = new Gilbert(
@@ -270,9 +280,9 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
       }
     );
 
-    await (await gilbert3.compile()).pipeTo(fsAdapter.write(distDir));
+    await (await gilbert3.compile()).pipeTo(fsAdapter.write(distDir3));
 
-    const arrayPatternFiles = await getAllFiles(distDir);
+    const arrayPatternFiles = await getAllFiles(distDir3);
 
     // Should produce same results
     assert.equal(
@@ -280,5 +290,44 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
       arrayPatternFiles.length,
       "Single pattern and array with single pattern should produce same results"
     );
+  });
+
+  test("should process static files from multiple streams (array input)", async () => {
+    // Each test gets a fresh, isolated tmp subdirectory
+    const distDir = makeDistDir();
+    await mkdir(distDir, { recursive: true });
+
+    // Two independent streams targeting different subsets of files.
+    // files/*.txt covers root-level text files; files/assets/**/* covers nested binary/asset files.
+    // Together they should produce a non-overlapping union in the output.
+    const stream1 = fsAdapter.read("files/*.txt");
+    const stream2 = fsAdapter.read("files/assets/**/*");
+
+    const gilbert = new Gilbert(
+      {
+        staticFiles: [stream1, stream2],
+      },
+      {
+        debug: true,
+      }
+    );
+
+    await (await gilbert.compile()).pipeTo(fsAdapter.write(distDir));
+
+    const outputFiles = await getAllFiles(distDir);
+
+    // Both streams must have contributed files
+    assert.ok(outputFiles.length > 0, "Should have output files from multiple streams");
+
+    const txtFiles = outputFiles.filter((f) => f.path.endsWith(".txt"));
+    const assetFiles = outputFiles.filter((f) => f.relativePath.startsWith("files/assets/"));
+
+    assert.ok(txtFiles.length > 0, "Should have .txt files from stream 1");
+    assert.ok(assetFiles.length > 0, "Should have asset files from stream 2");
+
+    // Verify no file is duplicated (all relative paths are unique)
+    const relativePaths = outputFiles.map((f) => f.relativePath);
+    const uniquePaths = new Set(relativePaths);
+    assert.equal(uniquePaths.size, relativePaths.length, "No files should be duplicated across streams");
   });
 });

--- a/services/gilbert/tests/static-files.test.js
+++ b/services/gilbert/tests/static-files.test.js
@@ -1,7 +1,7 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { resolve } from "node:path";
-import { readdir, stat, readFile, mkdir, rm } from "node:fs/promises";
+import { readdir, stat, readFile, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 
 // Gilbert and dependencies
@@ -13,9 +13,10 @@ const __dirname = resolve(new URL(".", import.meta.url).pathname);
 const srcDir = resolve(__dirname, "../../../tests/src");
 const filesDir = resolve(srcDir, "files");
 
-// Each test gets its own isolated tmp subdirectory — no shared state between tests
-let testIndex = 0;
-const makeDistDir = () => resolve(tmpdir(), `gilbert-static-files-${++testIndex}`);
+// Each test gets its own isolated tmp subdirectory with a random suffix — no shared state between tests
+const makeDistDir = async () => {
+  return await mkdtemp(resolve(tmpdir(), "gilbert-static-files-"));
+};
 
 // Create GilbertFS adapter instance for testing new constructor pattern
 const fsAdapter = new GilbertFS({ base: srcDir });
@@ -62,8 +63,7 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
 
   test("should process static files through Gilbert pipeline", async () => {
     // Each test gets a fresh, isolated tmp subdirectory
-    const distDir = makeDistDir();
-    await mkdir(distDir, { recursive: true });
+    const distDir = await makeDistDir();
 
     // Get expected file count from source directory
     const inputFiles = await getAllFiles(filesDir);
@@ -148,8 +148,7 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
 
   test("should preserve file structure and paths", async () => {
     // Each test gets a fresh, isolated tmp subdirectory
-    const distDir = makeDistDir();
-    await mkdir(distDir, { recursive: true });
+    const distDir = await makeDistDir();
 
     const gilbert = new Gilbert(
       {
@@ -182,8 +181,7 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
 
   test("should pass through files without modification", async () => {
     // Each test gets a fresh, isolated tmp subdirectory
-    const distDir = makeDistDir();
-    await mkdir(distDir, { recursive: true });
+    const distDir = await makeDistDir();
 
     const gilbert = new Gilbert(
       {
@@ -210,8 +208,7 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
 
   test("should handle array patterns to filter specific file types", async () => {
     // Each test gets a fresh, isolated tmp subdirectory; sub-phases use sibling dirs
-    const distDir = makeDistDir();
-    await mkdir(distDir, { recursive: true });
+    const distDir = await makeDistDir();
 
     // Create Gilbert instance for array pattern test
     const gilbert1 = new Gilbert(
@@ -249,8 +246,7 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
     }
 
     // Test single pattern vs array pattern should be equivalent for same pattern
-    const distDir2 = makeDistDir();
-    await mkdir(distDir2, { recursive: true });
+    const distDir2 = await makeDistDir();
 
     // Create new Gilbert instance for single pattern test
     const gilbert2 = new Gilbert(
@@ -267,8 +263,7 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
     const singlePatternFiles = await getAllFiles(distDir2);
 
     // Clean and test array with single pattern
-    const distDir3 = makeDistDir();
-    await mkdir(distDir3, { recursive: true });
+    const distDir3 = await makeDistDir();
 
     // Create new Gilbert instance for array pattern test
     const gilbert3 = new Gilbert(
@@ -294,8 +289,7 @@ await describe("Gilbert Static Files Pipeline", { concurrency: 1 }, () => {
 
   test("should process static files from multiple streams (array input)", async () => {
     // Each test gets a fresh, isolated tmp subdirectory
-    const distDir = makeDistDir();
-    await mkdir(distDir, { recursive: true });
+    const distDir = await makeDistDir();
 
     // Two independent streams targeting different subsets of files.
     // files/*.txt covers root-level text files; files/assets/**/* covers nested binary/asset files.

--- a/services/gilbert/tests/stylesheets.test.js
+++ b/services/gilbert/tests/stylesheets.test.js
@@ -2,25 +2,22 @@ import { test, describe } from "node:test";
 import assert from "node:assert";
 import { existsSync } from "node:fs";
 import { readdir, readFile, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import Gilbert from "../lib/index.js";
 import GilbertFS from "@tforster/gilbert-fs";
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 const rootSrcDir = path.resolve(__dirname, "../../../tests/src");
+const distDir = path.join(tmpdir(), "gilbert-stylesheets");
 
 // Create GilbertFS adapter instance
 const fsAdapter = new GilbertFS();
 
 await describe("Gilbert Stylesheets Pipeline", { concurrency: 1 }, () => {
   const cleanDist = async () => {
-    const distPath = path.join(__dirname, "dist");
-    try {
-      await rm(distPath, { recursive: true, force: true });
-      await mkdir(distPath, { recursive: true });
-    } catch {
-      await mkdir(distPath, { recursive: true });
-    }
+    await rm(distDir, { recursive: true, force: true });
+    await mkdir(distDir, { recursive: true });
   };
 
   test("should process stylesheets with StopTheParty app structure", async () => {
@@ -39,16 +36,15 @@ await describe("Gilbert Stylesheets Pipeline", { concurrency: 1 }, () => {
     );
 
     // Compile and pipe Gilbert output to filesystem destination using adapter
-    await (await gilbert.compile()).pipeTo(fsAdapter.write(path.join(__dirname, "dist")));
+    await (await gilbert.compile()).pipeTo(fsAdapter.write(distDir));
 
-    const outputDir = path.join(__dirname, "dist");
-    assert.ok(existsSync(outputDir), "Output directory should exist");
+    assert.ok(existsSync(distDir), "Output directory should exist");
 
-    const files = await readdir(outputDir);
+    const files = await readdir(distDir);
     const cssFiles = files.filter((file) => file.endsWith(".css"));
     assert.ok(cssFiles.length > 0, "At least one CSS file should be generated");
 
-    const mainCssPath = path.join(outputDir, "main.css");
+    const mainCssPath = path.join(distDir, "main.css");
     assert.ok(existsSync(mainCssPath), "main.css should exist");
 
     const content = await readFile(mainCssPath, "utf8");
@@ -78,18 +74,17 @@ await describe("Gilbert Stylesheets Pipeline", { concurrency: 1 }, () => {
     );
 
     // Compile and pipe Gilbert output to filesystem destination using adapter
-    await (await gilbert.compile()).pipeTo(fsAdapter.write(path.join(__dirname, "dist")));
+    await (await gilbert.compile()).pipeTo(fsAdapter.write(distDir));
 
-    const outputDir = path.join(__dirname, "dist");
-    assert.ok(existsSync(outputDir), "Output directory should exist");
+    assert.ok(existsSync(distDir), "Output directory should exist");
 
-    const files = await readdir(outputDir);
+    const files = await readdir(distDir);
     const cssFiles = files.filter((file) => file.endsWith(".css"));
     assert.ok(cssFiles.length > 0, "CSS files should be generated");
 
     // Should not have sourcemap files since sourcemap: false
     // Note: This test may see files from previous test runs, so we check the CSS content instead
-    const mainCssPath = path.join(outputDir, "main.css");
+    const mainCssPath = path.join(distDir, "main.css");
     assert.ok(existsSync(mainCssPath), "main.css should exist");
 
     const content = await readFile(mainCssPath, "utf8");

--- a/services/gilbert/tests/templates.test.js
+++ b/services/gilbert/tests/templates.test.js
@@ -2,7 +2,7 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readdir, readFile, mkdir } from "node:fs/promises";
+import { readdir, readFile, mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 
 // Gilbert and dependencies
@@ -16,9 +16,10 @@ const srcDir = resolve(__dirname, "../../../tests/src");
 const templatesDir = resolve(srcDir, "templates");
 const dataDir = resolve(srcDir, "data");
 
-// Each test gets its own isolated tmp subdirectory — no shared state between tests
-let testIndex = 0;
-const makeDistDir = () => resolve(tmpdir(), `gilbert-templates-${++testIndex}`);
+// Each test gets its own isolated tmp subdirectory with a random suffix — no shared state between tests
+const makeDistDir = async () => {
+  return await mkdtemp(resolve(tmpdir(), "gilbert-templates-"));
+};
 
 // Create GilbertFS adapter instances for testing
 const dataAdapter = new GilbertFS({ base: dataDir });
@@ -27,8 +28,7 @@ const outputAdapter = new GilbertFS(); // No base, use direct path
 
 await describe("Gilbert Template Pipeline", { concurrency: 1 }, () => {
   test("should process templates and generate HTML files", async () => {
-    const distDir = makeDistDir();
-    await mkdir(distDir, { recursive: true });
+    const distDir = await makeDistDir();
 
     // Create Gilbert instance with new API signature
     const gilbert = new Gilbert(
@@ -54,8 +54,7 @@ await describe("Gilbert Template Pipeline", { concurrency: 1 }, () => {
   });
 
   test("should populate template variables with data from JSON files", async () => {
-    const distDir = makeDistDir();
-    await mkdir(distDir, { recursive: true });
+    const distDir = await makeDistDir();
 
     // Create Gilbert instance with new API signature
     const gilbert = new Gilbert(
@@ -82,8 +81,7 @@ await describe("Gilbert Template Pipeline", { concurrency: 1 }, () => {
   });
 
   test("should load templates from multiple streams (array input)", async () => {
-    const distDir = makeDistDir();
-    await mkdir(distDir, { recursive: true });
+    const distDir = await makeDistDir();
 
     // Two separate adapter instances: one for root templates, one for components.
     // home.hbs uses {{> components/head.hbs}}, {{> components/header.hbs}}, etc.

--- a/services/gilbert/tests/templates.test.js
+++ b/services/gilbert/tests/templates.test.js
@@ -2,7 +2,8 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readdir, readFile, rm } from "node:fs/promises";
+import { readdir, readFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
 
 // Gilbert and dependencies
 import Gilbert from "../lib/index.js";
@@ -14,7 +15,10 @@ const __dirname = dirname(__filename);
 const srcDir = resolve(__dirname, "../../../tests/src");
 const templatesDir = resolve(srcDir, "templates");
 const dataDir = resolve(srcDir, "data");
-const distDir = resolve(__dirname, "dist");
+
+// Each test gets its own isolated tmp subdirectory — no shared state between tests
+let testIndex = 0;
+const makeDistDir = () => resolve(tmpdir(), `gilbert-templates-${++testIndex}`);
 
 // Create GilbertFS adapter instances for testing
 const dataAdapter = new GilbertFS({ base: dataDir });
@@ -23,8 +27,8 @@ const outputAdapter = new GilbertFS(); // No base, use direct path
 
 await describe("Gilbert Template Pipeline", { concurrency: 1 }, () => {
   test("should process templates and generate HTML files", async () => {
-    // Clean output directory and ensure it exists
-    await rm(distDir, { recursive: true, force: true });
+    const distDir = makeDistDir();
+    await mkdir(distDir, { recursive: true });
 
     // Create Gilbert instance with new API signature
     const gilbert = new Gilbert(
@@ -50,8 +54,8 @@ await describe("Gilbert Template Pipeline", { concurrency: 1 }, () => {
   });
 
   test("should populate template variables with data from JSON files", async () => {
-    // Clean output directory and ensure it exists
-    await rm(distDir, { recursive: true, force: true });
+    const distDir = makeDistDir();
+    await mkdir(distDir, { recursive: true });
 
     // Create Gilbert instance with new API signature
     const gilbert = new Gilbert(
@@ -75,5 +79,57 @@ await describe("Gilbert Template Pipeline", { concurrency: 1 }, () => {
 
     // Verify template variables were replaced with data values
     assert.ok(homepageOutput.includes(homepageData.title), `Homepage should contain title: "${homepageData.title}"`);
+  });
+
+  test("should load templates from multiple streams (array input)", async () => {
+    const distDir = makeDistDir();
+    await mkdir(distDir, { recursive: true });
+
+    // Two separate adapter instances: one for root templates, one for components.
+    // home.hbs uses {{> components/head.hbs}}, {{> components/header.hbs}}, etc.
+    // so both streams must be loaded before rendering begins.
+    const rootTemplatesAdapter = new GilbertFS({ base: templatesDir });
+    const componentsAdapter = new GilbertFS({ base: templatesDir });
+
+    const gilbert = new Gilbert(
+      {
+        templates: [rootTemplatesAdapter.read("*.hbs"), componentsAdapter.read("components/**/*.hbs")],
+        data: {
+          source: dataAdapter.read("**/*.json"),
+        },
+      },
+      {
+        debug: true,
+      }
+    );
+
+    await (await gilbert.compile()).pipeTo(outputAdapter.write(distDir));
+
+    // Should produce the same output as single-stream — all templates and partials resolve
+    const files = await readdir(distDir);
+    const htmlFiles = files.filter((f) => f.endsWith(".html"));
+    assert.ok(htmlFiles.length > 0, "Should generate at least one HTML file from array of template streams");
+
+    // about.hbs (root stream) renders /about.html with no conflicts — verify data binding works
+    const aboutData = JSON.parse(await readFile(resolve(dataDir, "about.json"), "utf8"));
+    const aboutOutput = await readFile(resolve(distDir, "about.html"), "utf8");
+    assert.ok(aboutOutput.length > 0, "about.html should not be empty");
+    assert.ok(aboutOutput.includes(aboutData.title), `about.html should contain title from about.json: "${aboutData.title}"`);
+  });
+
+  test("should throw on duplicate template keys across multiple streams", async () => {
+    // Two adapters with the same base and pattern yield identical keys — a clear collision.
+    const stream1 = new GilbertFS({ base: templatesDir }).read("*.hbs");
+    const stream2 = new GilbertFS({ base: templatesDir }).read("*.hbs");
+
+    const gilbert = new Gilbert(
+      {
+        templates: [stream1, stream2],
+        data: { source: dataAdapter.read("**/*.json") },
+      },
+      { debug: false }
+    );
+
+    await assert.rejects(() => gilbert.compile(), /Template collision/);
   });
 });


### PR DESCRIPTION
## Pull request overview

This PR expands the Gilbert engine and docs to support **multiple template sources** and **multiple static file sources** by accepting arrays of `ReadableStream<GilbertFile>`, and it improves test ergonomics by moving test outputs to `os.tmpdir()` plus adding a root test runner that prints a consolidated pass/fail summary.

**Changes:**
- Allow `templates` to be provided as `ReadableStream | ReadableStream[]` and load all template streams concurrently with collision detection.
- Allow `staticFiles` to be provided as `ReadableStream | ReadableStream[]` and process each stream through its own `StaticFilesPipeline`.
- Add `devops/test.js` root test wrapper + update tests to write to temp directories.